### PR TITLE
Add VA dashboard templates and accounting view

### DIFF
--- a/accounting/urls.py
+++ b/accounting/urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+
+from .views import accounting_va_dashboard
+
+urlpatterns = [
+    path('accounting/va/', accounting_va_dashboard, name='accounting_va_dashboard'),
+]

--- a/accounting/views.py
+++ b/accounting/views.py
@@ -1,0 +1,47 @@
+from datetime import timedelta
+
+from django.db.models import Sum
+from django.shortcuts import render
+from django.utils import timezone
+
+from .models import Invoice, Purchase
+
+
+def accounting_va_dashboard(request):
+    """Display sales and purchases with month-over-month KPIs."""
+    active_tab = request.GET.get("tab", "ventes")
+
+    now = timezone.now()
+    start_current_month = now.replace(day=1)
+    end_previous_month = start_current_month - timedelta(days=1)
+    start_previous_month = end_previous_month.replace(day=1)
+
+    invoices = Invoice.objects.filter(date__gte=start_current_month)
+    purchases = Purchase.objects.filter(date__gte=start_current_month)
+
+    invoice_total = invoices.aggregate(total=Sum("amount"))["total"] or 0
+    purchase_total = purchases.aggregate(total=Sum("amount"))["total"] or 0
+
+    prev_invoice_total = (
+        Invoice.objects.filter(date__range=(start_previous_month, end_previous_month))
+        .aggregate(total=Sum("amount"))["total"]
+        or 0
+    )
+    prev_purchase_total = (
+        Purchase.objects.filter(date__range=(start_previous_month, end_previous_month))
+        .aggregate(total=Sum("amount"))["total"]
+        or 0
+    )
+
+    context = {
+        "active_tab": active_tab,
+        "invoices": invoices,
+        "purchases": purchases,
+        "kpis": {
+            "invoice_total": invoice_total,
+            "purchase_total": purchase_total,
+            "invoice_mom": invoice_total - prev_invoice_total,
+            "purchase_mom": purchase_total - prev_purchase_total,
+        },
+    }
+    return render(request, "va_dashboard.html", context)

--- a/templates/partials/invoice_table.html
+++ b/templates/partials/invoice_table.html
@@ -1,0 +1,22 @@
+<table class="table is-fullwidth is-striped">
+  <thead>
+    <tr>
+      <th>Date</th>
+      <th>Client</th>
+      <th>Montant</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for invoice in invoices %}
+    <tr>
+      <td>{{ invoice.date|date:'Y-m-d' }}</td>
+      <td>{{ invoice.client }}</td>
+      <td>{{ invoice.amount }}</td>
+    </tr>
+    {% empty %}
+    <tr>
+      <td colspan="3">Aucune facture.</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>

--- a/templates/partials/kpi_panel.html
+++ b/templates/partials/kpi_panel.html
@@ -1,0 +1,6 @@
+<div class="panel">
+  <p><strong>Total ventes ce mois :</strong> {{ kpis.invoice_total }}</p>
+  <p><strong>Variation MoM ventes :</strong> {{ kpis.invoice_mom }}</p>
+  <p><strong>Total achats ce mois :</strong> {{ kpis.purchase_total }}</p>
+  <p><strong>Variation MoM achats :</strong> {{ kpis.purchase_mom }}</p>
+</div>

--- a/templates/partials/purchase_table.html
+++ b/templates/partials/purchase_table.html
@@ -1,0 +1,22 @@
+<table class="table is-fullwidth is-striped">
+  <thead>
+    <tr>
+      <th>Date</th>
+      <th>Fournisseur</th>
+      <th>Montant</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for purchase in purchases %}
+    <tr>
+      <td>{{ purchase.date|date:'Y-m-d' }}</td>
+      <td>{{ purchase.vendor }}</td>
+      <td>{{ purchase.amount }}</td>
+    </tr>
+    {% empty %}
+    <tr>
+      <td colspan="3">Aucun achat.</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>

--- a/templates/va_dashboard.html
+++ b/templates/va_dashboard.html
@@ -1,0 +1,27 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<div class="tabs is-boxed">
+  <ul>
+    <li class="{% if active_tab == 'ventes' %}is-active{% endif %}">
+      <a href="?tab=ventes">Ventes</a>
+    </li>
+    <li class="{% if active_tab == 'achats' %}is-active{% endif %}">
+      <a href="?tab=achats">Achats</a>
+    </li>
+  </ul>
+</div>
+
+<div class="columns">
+  <div class="column is-three-quarters">
+    {% if active_tab == 'ventes' %}
+      {% include 'partials/invoice_table.html' %}
+    {% else %}
+      {% include 'partials/purchase_table.html' %}
+    {% endif %}
+  </div>
+  <div class="column">
+    {% include 'partials/kpi_panel.html' %}
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Add VA dashboard template with tabs for Ventes/Achats and KPI side panel
- Implement reusable invoice and purchase table partials plus KPI panel
- Create `accounting_va_dashboard` view with month-over-month totals and route registration

## Testing
- `python -m py_compile accounting/views.py accounting/urls.py`
- `npx nx lint twenty-server` *(fails: 403 Forbidden fetching nx)*
- `npx nx test twenty-server` *(fails: 403 Forbidden fetching nx)*

------
https://chatgpt.com/codex/tasks/task_e_68af120e2548832182627fcf03de12f5