### PR TITLE
Add manager landing page template

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Twenty</title>
+  </head>
+  <body>
+    {% block content %}{% endblock %}
+  </body>
+</html>

--- a/templates/manager_landing.html
+++ b/templates/manager_landing.html
@@ -1,0 +1,74 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="video-container">
+  <video id="intro-video" autoplay muted class="fade-out-video">
+    <source src="/static/videos/manager_intro.mp4" type="video/mp4" />
+    Your browser does not support the video tag.
+  </video>
+</div>
+
+<div id="filter-bar" class="hidden">
+  <!-- FilterBar placeholder -->
+</div>
+
+<div id="card-grid" class="card-grid hidden">
+  <a href="/clients/" class="card">Clients</a>
+  <a href="/accounting/va/" class="card">Virtual Accounts</a>
+  <a href="/accounting/invoices/" class="card">Invoices</a>
+  <a href="#" class="card">Coming Soon</a>
+</div>
+
+<script>
+  const video = document.getElementById('intro-video');
+  const cardGrid = document.getElementById('card-grid');
+  const filterBar = document.getElementById('filter-bar');
+
+  setTimeout(() => {
+    video.classList.add('fade-out');
+    cardGrid.classList.remove('hidden');
+    filterBar.classList.remove('hidden');
+  }, 6000);
+
+  video.addEventListener('transitionend', () => {
+    video.remove();
+  });
+</script>
+
+<style>
+.video-container {
+  position: relative;
+}
+.fade-out-video {
+  width: 100%;
+  height: auto;
+  transition: opacity 1s ease-out;
+}
+.fade-out-video.fade-out {
+  opacity: 0;
+}
+.hidden {
+  display: none;
+}
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 1rem;
+  margin-top: 1rem;
+}
+.card {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #f5f5f5;
+  border-radius: 8px;
+  padding: 2rem;
+  text-decoration: none;
+  color: #333;
+  font-size: 1.25rem;
+  transition: background 0.3s;
+}
+.card:hover {
+  background: #e0e0e0;
+}
+</style>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add base template structure
- implement manager landing page with intro video fade-out and responsive cards

## Testing
- `yarn test` *(fails: Couldn't find a script named "test".)*
- `yarn lint` *(fails: Couldn't find a script named "lint".)*


------
https://chatgpt.com/codex/tasks/task_e_68af1208fe9c83218290ec5c94ad0222